### PR TITLE
Fixed import statement in request.js

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -1,8 +1,5 @@
 const request = require('superagent')
-
-import {
-  defaults
-} from './util'
+const { defaults } = require('./util')
 
 function sendRequest(opts = {}) {
   let {


### PR DESCRIPTION
Couldn't use the package from node.

Turns out there's an `import` statement in `request.js` where everything else seems to use `require()`.